### PR TITLE
typo "healps" replaced with "helps"

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -36,7 +36,7 @@ body:
     id: screenshot
     attributes:
       label: Screenshot / Screenshare
-      description: Please add screenshot or screenshare if that healps to describe the feature.
+      description: Please add screenshot or screenshare if that helps to describe the feature.
 
   - type: textarea
     id: additional-context


### PR DESCRIPTION
> First thing, PLEASE READ THIS: [ReactPlay Code Review Checklist](https://github.com/reactplay/react-play/wiki/ReactPlay-Code-Review-Checklist)

# Description

Fixes # (issue)
on the feature-request GitHub issue template, there is a typo in the Screenshot / Screenshare section description, where "healps" is used instead of "helps"

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Screenshots or example output

<!--- If you made any visual changes, include screenshot. -->
<!-- If you made any workflow changes, include a screenshare -->
<!--- If not relevant, delete this section. -->
